### PR TITLE
feat: 근태상세 직원 정보 컴포넌트 추가

### DIFF
--- a/frontend/src/components/attendance/AnnualInfo.tsx
+++ b/frontend/src/components/attendance/AnnualInfo.tsx
@@ -31,7 +31,7 @@ function AnnualInfo({ userId }: AnnualInfoProps) {
               flex: 1,
               p: 2,
               textAlign: 'center',
-              backgroundColor: '#f5f5f5',
+              backgroundColor: '#fcfcfc',
               borderRadius: 2,
             }}
           >

--- a/frontend/src/components/attendance/UserSummary.tsx
+++ b/frontend/src/components/attendance/UserSummary.tsx
@@ -1,0 +1,15 @@
+// UserSummary.tsx
+const UserSummary = () => {
+
+  return (
+    <>
+    <h3>직원 정보</h3>
+    <p>이름: 김성훈</p>
+    <p>직원코드: ABC123</p>
+    <p>부서: 개발</p>
+    <p>직책: 대리</p>
+    </>
+  )
+}
+
+export default UserSummary;

--- a/frontend/src/components/attendance/UserSummary.tsx
+++ b/frontend/src/components/attendance/UserSummary.tsx
@@ -1,4 +1,5 @@
 // UserSummary.tsx
+import { Box, Paper, Typography, Divider } from "@mui/material";
 import { dummyUsers } from './AttendDummy';
 
 interface UserSummaryProps {
@@ -6,16 +7,54 @@ interface UserSummaryProps {
 }
 
 const UserSummary = ({ userId }: UserSummaryProps) => {
-  const userSummary = dummyUsers.filter((user) => user.id === userId);
+  const user = dummyUsers.find((user) => user.id === userId);
+
+  if (!user) return null;
+
+  const infoItems = [
+    { label: '이름', value: user.name },
+    { label: '직원코드', value: user.emp_no },
+    { label: '부서', value: user.department },
+    { label: '직책', value: user.position },
+  ];
+
   return (
     <>
-    <h3>직원 정보</h3>
-    <p>이름: {userSummary[0].name }</p>
-    <p>직원코드: {userSummary[0].emp_no }</p>
-    <p>부서: {userSummary[0].department }</p>
-    <p>직책: {userSummary[0].position }</p>
+      <Typography variant="h6" fontWeight="bold" gutterBottom sx={{ mt: 4 }}>
+        직원 정보
+      </Typography>
+
+      <Paper
+        elevation={0}
+        variant="outlined"
+        sx={{
+          p: 3,
+          borderRadius: 2,
+          backgroundColor: '#fcfcfc',
+          mb: 4,
+        }}
+      >
+        <Box sx={{ display: 'flex', width: '100%' }}>
+          {infoItems.map((item, idx) => (
+            <Box
+              key={idx}
+              sx={{
+                flex: '1 1 25%',
+                minWidth: 0,
+              }}
+            >
+              <Typography variant="body2" color="textSecondary">
+                {item.label}
+              </Typography>
+              <Typography variant="subtitle1" fontWeight="medium">
+                {item.value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Paper>
     </>
-  )
-}
+  );
+};
 
 export default UserSummary;

--- a/frontend/src/components/attendance/UserSummary.tsx
+++ b/frontend/src/components/attendance/UserSummary.tsx
@@ -1,13 +1,19 @@
 // UserSummary.tsx
-const UserSummary = () => {
+import { dummyUsers } from './AttendDummy';
 
+interface UserSummaryProps {
+  userId: number;
+}
+
+const UserSummary = ({ userId }: UserSummaryProps) => {
+  const userSummary = dummyUsers.filter((user) => user.id === userId);
   return (
     <>
     <h3>직원 정보</h3>
-    <p>이름: 김성훈</p>
-    <p>직원코드: ABC123</p>
-    <p>부서: 개발</p>
-    <p>직책: 대리</p>
+    <p>이름: {userSummary[0].name }</p>
+    <p>직원코드: {userSummary[0].emp_no }</p>
+    <p>부서: {userSummary[0].department }</p>
+    <p>직책: {userSummary[0].position }</p>
     </>
   )
 }

--- a/frontend/src/pages/attendance/AttendanceDetailPage.tsx
+++ b/frontend/src/pages/attendance/AttendanceDetailPage.tsx
@@ -1,15 +1,21 @@
 // AttendanceDetailPage.tsx
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Stack, Typography } from "@mui/material";
 import AnnualInfo from "../../components/attendance/AnnualInfo";
 import AttendanceDetail from "../../components/attendance/AttendanceDetail";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+import { dummyUsers } from './AttendDummy';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 
 const AttendanceDetailPage = () => {
-  const { id } = useParams();
-  // id값 없을 경우 0으로 인지하여 없는 값이 됨
+  const { id } = useParams();   // id값 없을 경우 0으로 인지하여 없는 값이 됨
   const userId = id ? parseInt(id, 10) : 0;
-    
+  const navigate = useNavigate();
+
+  // 유저 이름 찾기
+  const user = dummyUsers.find(u => u.id === userId);
+  const userName = user?.name ?? "직원"; // 유저가 없을 경우 기본값
+
 
   return (
     // 전체 너비를 차지하는 래퍼
@@ -32,13 +38,18 @@ const AttendanceDetailPage = () => {
           px: 2,           // 좌우 패딩
         }}
       >
+        <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate(-1)}>
+            Back
+          </Button>
+        </Stack>
         <Typography
           variant="h4"
           component="h2"
           fontWeight="bold"
           sx={{ mb: 4 }}
         > 
-          근태관리 
+          {userName} 근태 상세
         </Typography>               
 
         {/* 직원 근태 상세 */}

--- a/frontend/src/pages/attendance/AttendanceDetailPage.tsx
+++ b/frontend/src/pages/attendance/AttendanceDetailPage.tsx
@@ -3,8 +3,9 @@ import { Box, Button, Stack, Typography } from "@mui/material";
 import AnnualInfo from "../../components/attendance/AnnualInfo";
 import AttendanceDetail from "../../components/attendance/AttendanceDetail";
 import { useParams, useNavigate } from "react-router-dom";
-import { dummyUsers } from './AttendDummy';
+import { dummyUsers } from '../../components/attendance/AttendDummy';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import UserSummary from "../../components/attendance/UserSummary";
 
 
 const AttendanceDetailPage = () => {
@@ -49,8 +50,11 @@ const AttendanceDetailPage = () => {
           fontWeight="bold"
           sx={{ mb: 4 }}
         > 
-          {userName} 근태 상세
+          <strong>{userName}</strong>님 근태 상세
         </Typography>               
+
+        {/* 유저 간략한 주요 정보 */}
+        <UserSummary />
 
         {/* 직원 근태 상세 */}
         <Box sx={{ mt: 3 }}>

--- a/frontend/src/pages/attendance/AttendanceDetailPage.tsx
+++ b/frontend/src/pages/attendance/AttendanceDetailPage.tsx
@@ -54,7 +54,7 @@ const AttendanceDetailPage = () => {
         </Typography>               
 
         {/* 유저 간략한 주요 정보 */}
-        <UserSummary />
+        <UserSummary userId={userId} />
 
         {/* 직원 근태 상세 */}
         <Box sx={{ mt: 3 }}>


### PR DESCRIPTION
## 07 Jul

### 근태 상세

- [x]  화면에서 뒤로가기 버튼 추가 ⇒ 완료
- [x]  id값에 맞는 이름 제목에 노출
    
    > **“최`슥`슥 직원 상세”**
    > 
    
    [[코드정리](https://www.notion.so/2299b2f7b0af8063848ac9cd416d66a6?pvs=21)](https://www.notion.so/2299b2f7b0af8063848ac9cd416d66a6?pvs=21)
    
- [x]  유저 정보 간략히 보여주는 영역 추가
    
    [[코드](https://www.notion.so/2299b2f7b0af80b5959ad9f369cf08a5?pvs=21)](https://www.notion.so/2299b2f7b0af80b5959ad9f369cf08a5?pvs=21)